### PR TITLE
port to ocaml-migrate-parsetree based ppx_deriving

### DIFF
--- a/src/fake_ppx_deriving.ml.in
+++ b/src/fake_ppx_deriving.ml.in
@@ -44,3 +44,4 @@ let derivers () = []
 
 let real = false
 
+module Selected_ast = Ppx_ast.Selected_ast

--- a/src/real_ppx_deriving.ml.in
+++ b/src/real_ppx_deriving.ml.in
@@ -1,2 +1,4 @@
 include Ppx_deriving
 let real = true
+
+module Selected_ast = Ppx_ast.Select_ast(Ppx_deriving.OCaml_version)

--- a/src/type_conv.ml
+++ b/src/type_conv.ml
@@ -312,7 +312,7 @@ module Deriver = struct
     let sig_type_ext  = resolve_opt Field.sig_type_ext  in
     (* Ppx deriving works on the compiler AST while type conv work on the version
        selected by Ppx_ast, so we need to convert. *)
-    let module Js = Ppx_ast.Selected_ast in
+    let module Js = Ppx_deriving.Selected_ast in
     let core_type =
       match Hashtbl.find_exn all name with
       | Alias _ -> None
@@ -422,7 +422,7 @@ module Deriver = struct
 
   module Ppx_deriving_import = struct
     include struct
-      open Migrate_parsetree.OCaml_current.Ast
+      open Ppx_deriving_backend.OCaml_version.Ast
       open Parsetree
 
       type ('output_ast, 'input_ast) generator
@@ -445,7 +445,7 @@ module Deriver = struct
       if !disable_import then () else begin
         (* Ppx deriving works on the compiler AST while type conv work on the version
            selected by Ppx_ast, so we need to convert. *)
-        let module Js = Ppx_ast.Selected_ast in
+        let module Js = Ppx_deriving.Selected_ast in
         let convert_args args =
           List.map args ~f:(fun (name, expr) ->
             (name, Js.to_ocaml Expression expr))

--- a/src/type_conv.mli
+++ b/src/type_conv.mli
@@ -109,7 +109,7 @@ val ignore : t -> unit
 (* This is used inside Jane Street to make ppx_deriving depend on ppx_type_conv. It's not
    meant to be used by casual users. *)
 module Ppx_deriving_import : sig
-  open Migrate_parsetree.OCaml_current.Ast
+  open Ppx_deriving_backend.OCaml_version.Ast
   open Parsetree
 
   type ('output_ast, 'input_ast) generator


### PR DESCRIPTION
This is a lot of boilerplate, maybe a better encoding is possible (making ppx_deriving registration interface aware of the supported ocaml_version?).
The targeted version of ppx_deriving can be found at: https://github.com/let-def/ppx_deriving 